### PR TITLE
net-tcp: Various fixes and clearer error messages for estats.

### DIFF
--- a/include/net/tcp_estats.h
+++ b/include/net/tcp_estats.h
@@ -25,10 +25,11 @@
 #define _TCP_ESTATS_H
 
 #include <net/sock.h>
-#include <linux/tcp.h>
 #include <linux/idr.h>
+#include <linux/in.h>
 #include <linux/jump_label.h>
 #include <linux/spinlock.h>
+#include <linux/tcp.h>
 #include <linux/workqueue.h>
 
 enum tcp_estats_sndlim_states {
@@ -112,11 +113,11 @@ extern struct static_key	tcp_estats_enabled;
  */
 struct tcp_estats_connection_table {
 	/* Connection table */
-	u32			AddressType;
-	struct { u8 data[16]; }	LocalAddress;
-	struct { u8 data[16]; }	RemAddress;
-	u16			LocalPort;
-	u16			RemPort;
+	u32							AddressType;
+	union { struct in_addr addr; struct in6_addr addr6; }	LocalAddress;
+	union { struct in_addr addr; struct in6_addr addr6; }	RemAddress;
+	u16							LocalPort;
+	u16							RemPort;
 };
 
 struct tcp_estats_perf_table {

--- a/include/net/tcp_estats_mib_var.h
+++ b/include/net/tcp_estats_mib_var.h
@@ -32,7 +32,7 @@ enum MIB_TABLE {
 };
 #define MAX_TABLE __MAX_TABLE
 
-extern int max_index[]; /* MAX_TABLE */
+extern int estats_max_index[]; /* MAX_TABLE */
 
 /* The official MIB states are enumerated differently than Linux's. */
 enum tcp_estats_states {
@@ -98,7 +98,7 @@ static inline int single_index(int inda, int indb)
 
 	if (inda > 0) {
 		for (i = 0; i < inda; i++) {
-			ret += max_index[i];
+			ret += estats_max_index[i];
 		}
 	}
 	return ret;
@@ -174,13 +174,15 @@ typedef enum ESTATS_PERF_INDEX {
 	CURRWINRCVD,
 	MAXRWINRCVD,
 	ZERORWINRCVD,
-	SNDLIMTRANSRWIN,
-	SNDLIMTRANSCWND,
 	SNDLIMTRANSSND,
+	SNDLIMTRANSCWND,
+	SNDLIMTRANSRWIN,
+	SNDLIMTRANSSTARTUP,
 	SNDLIMTRANSTSODEFER,
-	SNDLIMTIMERWIN,
-	SNDLIMTIMECWND,
 	SNDLIMTIMESND,
+	SNDLIMTIMECWND,
+	SNDLIMTIMERWIN,
+	SNDLIMTIMESTARTUP,
 	SNDLIMTIMETSODEFER,
         __PERF_INDEX_MAX
 } ESTATS_PERF_INDEX;

--- a/net/ipv4/tcp_estats.c
+++ b/net/ipv4/tcp_estats.c
@@ -246,13 +246,17 @@ void tcp_estats_establish(struct sock *sk)
 	conn_table->RemPort = ntohs(inet->inet_dport);
 
 	if (conn_table->AddressType == TCP_ESTATS_ADDRTYPE_IPV4) {
-		memcpy(&conn_table->LocalAddress, &inet->inet_rcv_saddr, 4);
-		memcpy(&conn_table->RemAddress, &inet->inet_daddr, 4);
+		memcpy(&conn_table->LocalAddress.addr, &inet->inet_rcv_saddr,
+		       sizeof(struct in_addr));
+		memcpy(&conn_table->RemAddress.addr, &inet->inet_daddr,
+		       sizeof(struct in_addr));
 	}
 #if defined(CONFIG_IPV6) || defined(CONFIG_IPV6_MODULE)
 	else if (conn_table->AddressType == TCP_ESTATS_ADDRTYPE_IPV6) {
-		memcpy(&conn_table->LocalAddress, &(inet6_sk(sk)->saddr), 16);
-		memcpy(&conn_table->RemAddress, &(inet6_sk(sk)->daddr), 16);
+		memcpy(&conn_table->LocalAddress.addr6, &(inet6_sk(sk)->saddr),
+		       sizeof(struct in6_addr));
+		memcpy(&conn_table->RemAddress.addr6, &(inet6_sk(sk)->daddr),
+		       sizeof(struct in6_addr));
 	}
 #endif
 	else {


### PR DESCRIPTION
Change LocalAddress and RemoteAddress format to be native addr type.
Reorder variables in netlink enums to match tables. Add clearer error
messages throughout netlink module.
