### PR TITLE
net-tcp: Change tcp_estats LocalAddress and RemoteAddress format.

### DIFF
--- a/include/net/tcp_estats.h
+++ b/include/net/tcp_estats.h
@@ -25,10 +25,11 @@
 #define _TCP_ESTATS_H
 
 #include <net/sock.h>
-#include <linux/tcp.h>
 #include <linux/idr.h>
+#include <linux/in.h>
 #include <linux/jump_label.h>
 #include <linux/spinlock.h>
+#include <linux/tcp.h>
 #include <linux/workqueue.h>
 
 enum tcp_estats_sndlim_states {
@@ -113,8 +114,8 @@ extern struct static_key	tcp_estats_enabled;
 struct tcp_estats_connection_table {
 	/* Connection table */
 	u32			AddressType;
-	struct { u8 data[16]; }	LocalAddress;
-	struct { u8 data[16]; }	RemAddress;
+	union { struct in_addr addr; struct in6_addr addr6; }	LocalAddress;
+	union { struct in_addr addr; struct in6_addr addr6; }	RemAddress;
 	u16			LocalPort;
 	u16			RemPort;
 };

--- a/net/ipv4/tcp_estats.c
+++ b/net/ipv4/tcp_estats.c
@@ -271,13 +271,17 @@ void tcp_estats_establish(struct sock *sk)
 	conn_table->RemPort = ntohs(inet->inet_dport);
 
 	if (conn_table->AddressType == TCP_ESTATS_ADDRTYPE_IPV4) {
-		memcpy(&conn_table->LocalAddress, &inet->inet_rcv_saddr, 4);
-		memcpy(&conn_table->RemAddress, &inet->inet_daddr, 4);
+		memcpy(&conn_table->LocalAddress.addr, &inet->inet_rcv_saddr,
+		       sizeof(struct in_addr));
+		memcpy(&conn_table->RemAddress, &inet->inet_daddr,
+		       sizeof(struct in_addr));
 	}
 #if defined(CONFIG_IPV6) || defined(CONFIG_IPV6_MODULE)
 	else if (conn_table->AddressType == TCP_ESTATS_ADDRTYPE_IPV6) {
-		memcpy(&conn_table->LocalAddress, &(inet6_sk(sk)->saddr), 16);
-		memcpy(&conn_table->RemAddress, &(inet6_sk(sk)->daddr), 16);
+		memcpy(&conn_table->LocalAddress, &(inet6_sk(sk)->saddr),
+		       sizeof(struct in6_addr));
+		memcpy(&conn_table->RemAddress, &(inet6_sk(sk)->daddr),
+		       sizeof(struct in6_addr));
 	}
 #endif
 	else {


### PR DESCRIPTION
The tcp_estats connection table should store the local and remote
addreses in native in[6]_addr format instead of converting awkwardly to
char buffers.
