### PR TITLE
net-tcp: Remove deadlocks and race conditions from TCP estats.

### DIFF
--- a/include/net/tcp_estats.h
+++ b/include/net/tcp_estats.h
@@ -282,12 +282,14 @@ struct tcp_estats {
 	ktime_t				current_ts;
 	struct timeval			start_tv;
 
-        int                             queued;
-        struct work_struct              create_notify;
-        struct work_struct              establish_notify;
-        struct delayed_work             destroy_notify;
+        int				queued;
+        struct work_struct		create_notify;
+        struct work_struct		establish_notify;
+        struct delayed_work		destroy_notify;
 
 	struct tcp_estats_tables	tables;
+
+	struct rcu_head			rcu;
 };
 
 extern struct idr tcp_estats_idr;
@@ -305,8 +307,8 @@ extern spinlock_t tcp_estats_idr_lock;
 extern int  tcp_estats_create(struct sock *sk, enum tcp_estats_addrtype t,
 			      int active);
 extern void tcp_estats_destroy(struct sock *sk);
-extern void tcp_estats_free(struct tcp_estats *stats);
 extern void tcp_estats_establish(struct sock *sk);
+extern void tcp_estats_free(struct rcu_head *rcu);
 
 extern void tcp_estats_update_snd_nxt(struct tcp_sock *tp);
 extern void tcp_estats_update_acked(struct tcp_sock *tp, u32 ack);
@@ -334,10 +336,18 @@ static inline void tcp_estats_use(struct tcp_estats *stats)
 	atomic_inc(&stats->users);
 }
 
+static inline int tcp_estats_use_if_valid(struct tcp_estats *stats)
+{
+	return atomic_inc_not_zero(&stats->users);
+}
+
 static inline void tcp_estats_unuse(struct tcp_estats *stats)
 {
-	if (atomic_dec_and_test(&stats->users))
-		tcp_estats_free(stats);
+	if (atomic_dec_and_test(&stats->users)) {
+		sock_put(stats->sk);
+		stats->sk = NULL;
+		call_rcu(&stats->rcu, tcp_estats_free);
+	}
 }
 
 #else /* !CONFIG_TCP_ESTATS */


### PR DESCRIPTION
Ensure correct spin_locks are used throughout the TCP estats code, and
that returned pointers from idr_\* are checked and locked before being
used. Add rcu_read_lock use and associated synchronization point.

Added some uses of jiffies_to_msec instead of manually converting.
